### PR TITLE
increasing browser compatibility by calling Promise['finally']

### DIFF
--- a/src/delayLocationChange.js
+++ b/src/delayLocationChange.js
@@ -33,7 +33,7 @@
 			};
 			function addPromise(promise){
 				unfinishedPromises++;
-				promise.finally(checkPromises);
+				promise['finally'](checkPromises);
 			}
 			var unlisten = $rootScope.$on("$locationChangeStart",function(e,toUrl,fromUrl){
 				changeStarted = true;

--- a/src/visor.js
+++ b/src/visor.js
@@ -357,7 +357,7 @@
                 _authenticationPromise = deferred.promise;
                 $injector.invoke(config.authenticate)
                     .then(onAuthenticationSuccess,onAuthenticationFailed)
-                    .finally(function(){
+                    ['finally'](function(){
                         deferred.resolve(Visor.authData)
                     });
                 return deferred.promise;

--- a/src/visor.permissions.js
+++ b/src/visor.permissions.js
@@ -35,7 +35,7 @@
                         $q.all(config.doBeforeFirstCheck.map(function(cb){
                             return $injector.invoke(cb)
                         }))
-                        .finally(function(){
+                        ['finally'](function(){
                             finishedBeforeCheck = true;
                             if (handlePermission(next,permissions)) {
                                 waitForMe.resolve(true);


### PR DESCRIPTION
Calling Promise['finally'] should increase support for older browsers.

According to the [AngularJS documentation for $q](https://docs.angularjs.org/api/ng/service/$q#the-promise-api):

```
 *   Because `finally` is a reserved word in JavaScript and reserved keywords are not supported as
 *   property names by ES3, you'll need to invoke the method like `promise['finally'](callback)` to
 *   make your code IE8 and Android 2.x compatible.
```
